### PR TITLE
chore: Ignore dev files

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: [],
+  skipFiles: ["./abstracts/dev","./libraries/dev"],
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@ import * as extensions from "./extensions/index.test";
 import * as libraries from "./libraries/index.test";
 
 describe("Scenario", async function () {
-  // abstracts.run();
+  abstracts.run();
   extensions.run();
-  // libraries.run();
+  libraries.run();
 });


### PR DESCRIPTION
I have excluded the development files from the coverage tests.

<img width="789" alt="Screenshot 2567-09-16 at 09 10 10" src="https://github.com/user-attachments/assets/536df6d5-d53e-4bfa-ad98-5a93cc1ee9cf">

If the test results do not match the image above, please run `npx hardhat clean`.